### PR TITLE
javax.transaction.xa classes should not be transformed to jakarta

### DIFF
--- a/src/main/resources/dev/hargrave/transformer/jakarta-rules.properties
+++ b/src/main/resources/dev/hargrave/transformer/jakarta-rules.properties
@@ -111,7 +111,6 @@ jakarta.packages: \
 	javax/servlet/jsp/jstl/tlv=jakarta/servlet/jsp/jstl/tlv,\
 	javax/servlet/jsp/tagext=jakarta/servlet/jsp/tagext,\
 	javax/transaction=jakarta/transaction,\
-	javax/transaction/xa=jakarta/transaction/xa,\
 	javax/validation=jakarta/validation,\
 	javax/validation/bootstrap=jakarta/validation/bootstrap,\
 	javax/validation/constraints=jakarta/validation/constraints,\

--- a/src/test/java/dev/hargrave/transformer/AppTest.java
+++ b/src/test/java/dev/hargrave/transformer/AppTest.java
@@ -115,6 +115,14 @@ public class AppTest {
 				.hasSize(1)
 				.flatExtracting(a -> Arrays.asList(a.exceptions))
 				.containsExactlyInAnyOrder("jakarta/servlet/ServletException", "java/io/IOException");
+			softly.assertThat(cf.fields)
+				.filteredOn(f -> f.name.equals("xaResource"))
+				.hasSize(1)
+				.allMatch(f -> f.descriptor.equals("Ljavax/transaction/xa/XAResource;"));
+			softly.assertThat(cf.fields)
+				.filteredOn(f -> f.name.equals("transactionSynchronizationRegistry"))
+				.hasSize(1)
+				.allMatch(f -> f.descriptor.equals("Ljakarta/transaction/TransactionSynchronizationRegistry;"));
 		}
 	}
 

--- a/src/test/java/test/sample/javaee/JavaEEServlet.java
+++ b/src/test/java/test/sample/javaee/JavaEEServlet.java
@@ -7,10 +7,16 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.xa.XAResource;
 
 public class JavaEEServlet extends HttpServlet implements Servlet {
 
 	private static final long serialVersionUID = 1L;
+	@SuppressWarnings("unused")
+	private XAResource xaResource;
+	@SuppressWarnings("unused")
+	private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {


### PR DESCRIPTION
I think that javax.transaction.xa is missing a leading "!", so added that.